### PR TITLE
Remove Genius from Lyrics Plus docs

### DIFF
--- a/docs/advanced-usage/custom-apps.md
+++ b/docs/advanced-usage/custom-apps.md
@@ -97,7 +97,7 @@ spicetify apply
 
 ### Lyrics Plus
 
-Get access to the current track's lyrics from various lyrics providers (Musixmatch, Netease, Genius). Learn more [here](https://github.com/spicetify/cli/tree/main/CustomApps/lyrics-plus).
+Get access to the current track's lyrics from various lyrics providers (Musixmatch, Netease, lrclib). Learn more [here](https://github.com/spicetify/cli/tree/main/CustomApps/lyrics-plus).
 
 Colors, lyrics providers can be customized in config menu (in Profile menu, top right button with your user name).
 

--- a/docs/advanced-usage/custom-apps.md
+++ b/docs/advanced-usage/custom-apps.md
@@ -97,7 +97,7 @@ spicetify apply
 
 ### Lyrics Plus
 
-Get access to the current track's lyrics from various lyrics providers (Musixmatch, Netease, lrclib). Learn more [here](https://github.com/spicetify/cli/tree/main/CustomApps/lyrics-plus).
+Get access to the current track's lyrics from various lyrics providers (Musixmatch, Netease, LRCLIB). Learn more [here](https://github.com/spicetify/cli/tree/main/CustomApps/lyrics-plus).
 
 Colors, lyrics providers can be customized in config menu (in Profile menu, top right button with your user name).
 


### PR DESCRIPTION
Genius has been disabled, so references should be removed from the docs.
![image](https://github.com/spicetify/docs/assets/47907719/e1c3fd33-23c3-4c46-8848-25229c9dc69e)
This PR can be merged as 1 commit.