### PR TITLE
fix: code block formatting

### DIFF
--- a/docs/development/spicetify-creator/building-and-testing.md
+++ b/docs/development/spicetify-creator/building-and-testing.md
@@ -12,14 +12,14 @@ Open a terminal in the project's directory and run this:
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="npm" default>
-
+    ```shell
     npm run build
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="Yarn">
-
+    ```shell
     yarn run build
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -27,20 +27,20 @@ Then make sure you've added your app to Spicetify's config by running this:
 
 <Tabs groupId="app-types">
   <TabItem value="extension" label="Extension" default>
-
+    ```shell
     spicetify config extensions my-app.js
-
+    ```
   </TabItem>
   <TabItem value="custom-app" label="Custom App">
-
+    ```shell
     spicetify config custom_apps my-app
-
+    ```
   </TabItem>
 </Tabs>
 
 Finally, do
 
-```
+```shell
 spicetify apply
 ```
 
@@ -54,14 +54,14 @@ Watching means that it'll rebuild the app every time the code changes.
 Go into your project's directory and enter the following command:
 <Tabs groupId="package-managers">
 <TabItem value="npm" label="npm" default>
-
+    ```shell
     npm run watch
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="Yarn">
-
+    ```shell
     yarn run watch
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -69,14 +69,14 @@ Then, run Spotify in watch mode:
 
 <Tabs groupId="app-types">
   <TabItem value="extension" label="Extension" default>
-
+    ```shell
     spicetify watch -le
-
+    ```
   </TabItem>
   <TabItem value="custom-app" label="Custom App">
-
+    ```shell
     spicetify watch -la
-
+    ```
   </TabItem>
 </Tabs>
 
@@ -86,14 +86,14 @@ If you want to upload the build files with your repository or just see them, you
 
 <Tabs groupId="package-managers">
   <TabItem value="npm" label="npm" default>
-
+    ```shell
     npm run build-local
-
+    ```
   </TabItem>
   <TabItem value="yarn" label="Yarn">
-
+    ```shell
     yarn run build-local
-
+    ```
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Fix code block formatting on [Building and Testing](https://spicetify.app/docs/development/spicetify-creator/building-and-testing) page.