### PR TITLE
fix(installation): update spotify apt pubkey

### DIFF
--- a/docs/advanced-usage/installation.md
+++ b/docs/advanced-usage/installation.md
@@ -91,7 +91,7 @@ Apps installed from Snap **cannot be modified** so you need to follow these step
 2. Install Spotify using `apt`:
 
 ```sh
-curl -sS https://download.spotify.com/debian/pubkey_6224F9941A8AA6D1.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
+curl -sS https://download.spotify.com/debian/pubkey_C85668DF69375001.gpg | sudo gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/spotify.gpg
 echo "deb http://repository.spotify.com stable non-free" | sudo tee /etc/apt/sources.list.d/spotify.list
 sudo apt-get update && sudo apt-get install spotify-client
 ```


### PR DESCRIPTION
The commands listed in the docs right now lead to an error as the url of the gpg key is incorrect. See [https://www.spotify.com/us/download/linux/](https://www.spotify.com/us/download/linux/) for the new and working url
