### PR TITLE
chore: add throwback to theme repo list

### DIFF
--- a/docs/advanced-usage/themes.md
+++ b/docs/advanced-usage/themes.md
@@ -20,4 +20,5 @@ For this reason, the theming heroes of the Spicetify community have created a hu
 9. [Skaytacium/Gruvify](https://github.com/Skaytacium/Gruvify)
 10. [dracula/spicetify](https://github.com/dracula/spicetify)
 11. [Spotify Dark](https://github.com/SyndiShanX/Spotify-Dark)
-12. Insert your theme here!
+12. [bluedrift/Spicetify-Throwback](https://github.com/bluedrift/Spicetify-Throwback)
+13. Insert your theme here!


### PR DESCRIPTION
Hiya! I'm developing the following theme inspired by the look of the original 2010's-era Spotify desktop client. Please check it out if you'd like!

https://github.com/bluedrift/Spicetify-Throwback