### PR TITLE
Removes redundant wording in feature description

### DIFF
--- a/src/components/HomepageFeatures.tsx
+++ b/src/components/HomepageFeatures.tsx
@@ -16,7 +16,7 @@ const FeatureList = [
     title: 'Extensions',
     image: require('@site/static/images/extension.png').default,
     description: (
-      <>Small bonus little features that can be sprinkled across Spotify.</>
+      <>Small bonus features that can be sprinkled across Spotify.</>
     ),
   },
   {


### PR DESCRIPTION
Improves clarity in the Extensions feature description by removing the redundant word "little" (small and little have the same meaning)